### PR TITLE
Add test suite, CI pipeline, and PyPI publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,58 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install ruff
+      - run: ruff check src/ tests/
+      - run: ruff format --check src/ tests/
+
+  test:
+    name: Test (Python ${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.9", "3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - run: pip install -e ".[dev]"
+      - run: python -m pytest tests/ --cov=alchemycv --cov-report=xml -q
+      - name: Upload coverage
+        if: matrix.python-version == '3.12'
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: coverage.xml
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    needs: [lint, test]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install build
+      - run: python -m build
+      - name: Verify package
+        run: pip install dist/*.whl && python -c "import alchemycv; print('Package OK')"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,27 @@
+name: Publish to PyPI
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+jobs:
+  build-and-publish:
+    name: Build and Publish
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install build tools
+        run: pip install build
+
+      - name: Build package
+        run: python -m build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,13 @@ dependencies = [
     "matplotlib"
 ]
 
+[project.optional-dependencies]
+dev = [
+    "pytest>=7.0",
+    "pytest-cov>=4.0",
+    "ruff>=0.4.0",
+]
+
 [project.urls]
 "Homepage" = "https://github.com/kouya-marino/AlchemyCV"
 "Bug Tracker" = "https://github.com/kouya-marino/AlchemyCV/issues"
@@ -35,3 +42,14 @@ dependencies = [
 # This creates the 'alchemycv' command to run your app
 [project.scripts]
 alchemycv = "alchemycv.app:main"
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "-v --tb=short"
+
+[tool.ruff]
+target-version = "py38"
+line-length = 120
+
+[tool.ruff.lint]
+select = ["E", "F", "W", "I"]

--- a/src/alchemycv/app.py
+++ b/src/alchemycv/app.py
@@ -10,8 +10,11 @@ import logging
 import sys
 import threading
 import tkinter as tk
-from tkinter import filedialog, ttk, messagebox
+from tkinter import filedialog, messagebox, ttk
 from typing import Any
+
+import cv2
+import numpy as np
 
 from .constants import (
     CHANNEL_DATA,
@@ -22,24 +25,22 @@ from .constants import (
 )
 from .pipeline import engine as pipeline_engine
 from .pipeline.frequency import create_filter_mask
-from .state.manager import UndoManager
 from .state import settings as settings_io
+from .state.manager import UndoManager
 from .ui.canvas import ImageCanvas
 from .ui.control_panel import ControlPanel
 from .utils import load_image, save_image
 
 # Optional matplotlib
 try:
-    from matplotlib.figure import Figure
     from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg
+    from matplotlib.figure import Figure
+
     MATPLOTLIB_AVAILABLE = True
 except ImportError:
     MATPLOTLIB_AVAILABLE = False
 
 log = logging.getLogger(__name__)
-
-import cv2
-import numpy as np
 
 
 class AdvancedFilterApp:
@@ -282,9 +283,7 @@ class AdvancedFilterApp:
 
         # Update display-mode radio button states
         if hasattr(self.controls, "channel_display_rb"):
-            self.controls.channel_display_rb.config(
-                state="normal" if sel["channel_enabled"] else "disabled"
-            )
+            self.controls.channel_display_rb.config(state="normal" if sel["channel_enabled"] else "disabled")
         if hasattr(self.controls, "enhanced_display_rb"):
             self.controls.enhanced_display_rb.config(
                 state="normal" if sel["enhancement"] != "None" or sel["frequency"] != "None" else "disabled"
@@ -325,7 +324,7 @@ class AdvancedFilterApp:
             messagebox.showwarning("No Image", "Open an image first.")
             return
         try:
-            from .pipeline import preprocessing, enhancement, frequency, channels
+            from .pipeline import channels, enhancement, frequency, preprocessing
 
             params: dict[str, Any] = {}
             for k, v in self.param_vars.items():
@@ -379,7 +378,7 @@ class AdvancedFilterApp:
             messagebox.showwarning("No Image", "Open an image first.")
             return
         try:
-            from .pipeline import preprocessing, enhancement
+            from .pipeline import enhancement, preprocessing
 
             params: dict[str, Any] = {}
             for k, v in self.param_vars.items():

--- a/src/alchemycv/constants.py
+++ b/src/alchemycv/constants.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
-import cv2
-import numpy as np
 from typing import Any
+
+import cv2
 
 # ---------------------------------------------------------------------------
 # Filter / stage data structures

--- a/src/alchemycv/pipeline/edges.py
+++ b/src/alchemycv/pipeline/edges.py
@@ -57,9 +57,11 @@ def process(image: np.ndarray, edge_name: str, params: dict[str, Any]) -> np.nda
 
 def _sobel_factory(ksize: int):
     """Return a callable ``(image, axis) -> gradient`` for Sobel."""
+
     def _apply(img: np.ndarray, axis: str) -> np.ndarray:
         dx, dy = (1, 0) if axis == "X" else (0, 1)
         return cv2.Sobel(img, cv2.CV_64F, dx, dy, ksize=ksize)
+
     return _apply
 
 
@@ -71,4 +73,4 @@ def _directional_filter(image: np.ndarray, direction: str, grad_fn) -> np.ndarra
     # Magnitude
     gx = grad_fn(image, "X").astype(np.float64)
     gy = grad_fn(image, "Y").astype(np.float64)
-    return cv2.convertScaleAbs(np.sqrt(gx ** 2 + gy ** 2))
+    return cv2.convertScaleAbs(np.sqrt(gx**2 + gy**2))

--- a/src/alchemycv/pipeline/engine.py
+++ b/src/alchemycv/pipeline/engine.py
@@ -12,7 +12,7 @@ from typing import Any
 import cv2
 import numpy as np
 
-from . import preprocessing, enhancement, frequency, channels, masking, edges, morphology, contours
+from . import channels, contours, edges, enhancement, frequency, masking, morphology, preprocessing
 
 log = logging.getLogger(__name__)
 
@@ -43,9 +43,7 @@ def run(
     extracted_channel = None
 
     if sel["channel_enabled"]:
-        image_for_masking = channels.process(
-            freq_filtered_image, sel["color_space"], sel["channel"]
-        )
+        image_for_masking = channels.process(freq_filtered_image, sel["color_space"], sel["channel"])
         extracted_channel = image_for_masking.copy()
 
     otsu_threshold = None

--- a/src/alchemycv/pipeline/enhancement.py
+++ b/src/alchemycv/pipeline/enhancement.py
@@ -65,6 +65,7 @@ def process(image: np.ndarray, enhance_name: str, params: dict[str, Any]) -> np.
 # Internal implementations
 # ------------------------------------------------------------------
 
+
 def _hist_equalize(image: np.ndarray) -> np.ndarray:
     if len(image.shape) == 2:
         return cv2.equalizeHist(image)
@@ -86,9 +87,7 @@ def _gamma_correction(image: np.ndarray, gamma: float) -> np.ndarray:
     if gamma <= 0:
         gamma = 0.01
     inv_gamma = 1.0 / gamma
-    table = np.array(
-        [((i / 255.0) ** inv_gamma) * 255 for i in range(256)]
-    ).astype("uint8")
+    table = np.array([((i / 255.0) ** inv_gamma) * 255 for i in range(256)]).astype("uint8")
     return cv2.LUT(image, table)
 
 

--- a/src/alchemycv/pipeline/frequency.py
+++ b/src/alchemycv/pipeline/frequency.py
@@ -21,8 +21,7 @@ def process(image: np.ndarray, filter_name: str, params: dict[str, Any]) -> np.n
     rows, cols = gray.shape
     m_rows = cv2.getOptimalDFTSize(rows)
     m_cols = cv2.getOptimalDFTSize(cols)
-    padded = cv2.copyMakeBorder(gray, 0, m_rows - rows, 0, m_cols - cols,
-                                cv2.BORDER_CONSTANT, value=0)
+    padded = cv2.copyMakeBorder(gray, 0, m_rows - rows, 0, m_cols - cols, cv2.BORDER_CONSTANT, value=0)
 
     planes = [np.float32(padded), np.zeros(padded.shape, np.float32)]
     complex_i = cv2.merge(planes)
@@ -71,13 +70,13 @@ def create_filter_mask(
     if filter_type == "Ideal Low-Pass":
         mask = (D <= D0).astype(np.float32)
     elif filter_type == "Gaussian Low-Pass":
-        mask = np.exp(-(D ** 2) / (2 * D0 ** 2))
+        mask = np.exp(-(D**2) / (2 * D0**2))
     elif filter_type == "Butterworth Low-Pass":
         mask = 1.0 / (1.0 + (D / D0) ** (2 * n))
     elif filter_type == "Ideal High-Pass":
         mask = (D > D0).astype(np.float32)
     elif filter_type == "Gaussian High-Pass":
-        mask = 1.0 - np.exp(-(D ** 2) / (2 * D0 ** 2))
+        mask = 1.0 - np.exp(-(D**2) / (2 * D0**2))
     elif filter_type == "Butterworth High-Pass":
         with np.errstate(divide="ignore", invalid="ignore"):
             mask = 1.0 / (1.0 + (D0 / D) ** (2 * n))

--- a/src/alchemycv/pipeline/masking.py
+++ b/src/alchemycv/pipeline/masking.py
@@ -46,11 +46,7 @@ def process(
 
     if filter_type == "adaptive_thresh":
         method_str = params.get("filter_Adaptive_Method", "Gaussian C")
-        method = (
-            cv2.ADAPTIVE_THRESH_MEAN_C
-            if method_str == "Mean C"
-            else cv2.ADAPTIVE_THRESH_GAUSSIAN_C
-        )
+        method = cv2.ADAPTIVE_THRESH_MEAN_C if method_str == "Mean C" else cv2.ADAPTIVE_THRESH_GAUSSIAN_C
         type_str = params.get("filter_Threshold_Type", "Binary")
         thresh_type = cv2.THRESH_BINARY if type_str == "Binary" else cv2.THRESH_BINARY_INV
         bsize = _ensure_odd(int(params.get("filter_Block_Size", 11)))

--- a/src/alchemycv/ui/control_panel.py
+++ b/src/alchemycv/ui/control_panel.py
@@ -22,6 +22,7 @@ from .widgets import build_dynamic_panel, create_param_row, create_slider_and_en
 # Check matplotlib availability once
 try:
     from matplotlib.figure import Figure  # noqa: F401
+
     MATPLOTLIB_AVAILABLE = True
 except ImportError:
     MATPLOTLIB_AVAILABLE = False
@@ -92,14 +93,10 @@ class ControlPanel:
         top.pack(side=tk.TOP, fill=tk.X, pady=(0, 10))
         top.columnconfigure((0, 1, 2, 3), weight=1)
 
-        ttk.Button(top, text="Open Image", command=self.app.open_image).grid(
-            row=0, column=0, sticky="ew", padx=(0, 2)
-        )
+        ttk.Button(top, text="Open Image", command=self.app.open_image).grid(row=0, column=0, sticky="ew", padx=(0, 2))
         self.save_button = ttk.Button(top, text="Save Image", command=self.app.save_image, state="disabled")
         self.save_button.grid(row=0, column=1, sticky="ew", padx=2)
-        ttk.Button(top, text="Load Settings", command=self.app.load_settings).grid(
-            row=0, column=2, sticky="ew", padx=2
-        )
+        ttk.Button(top, text="Load Settings", command=self.app.load_settings).grid(row=0, column=2, sticky="ew", padx=2)
         ttk.Button(top, text="Save Settings", command=self.app.save_settings).grid(
             row=0, column=3, sticky="ew", padx=(2, 0)
         )
@@ -118,8 +115,11 @@ class ControlPanel:
         frame = ttk.LabelFrame(parent, text="1. Pre-processing", padding="10")
         frame.pack(side=tk.TOP, fill=tk.X, pady=(0, 10))
         ttk.OptionMenu(
-            frame, self.app.selected_preproc, self.app.selected_preproc.get(),
-            *PREPROCESSING_DATA.keys(), command=self.on_preproc_change,
+            frame,
+            self.app.selected_preproc,
+            self.app.selected_preproc.get(),
+            *PREPROCESSING_DATA.keys(),
+            command=self.on_preproc_change,
         ).pack(fill=tk.X)
         self.preproc_parameter_frame = ttk.Frame(frame, padding=(0, 10, 0, 0))
         self.preproc_parameter_frame.pack(fill=tk.X)
@@ -128,8 +128,11 @@ class ControlPanel:
         frame = ttk.LabelFrame(parent, text="2. Image Enhancement", padding="10")
         frame.pack(side=tk.TOP, fill=tk.X, pady=(0, 10))
         ttk.OptionMenu(
-            frame, self.app.selected_enhancement, self.app.selected_enhancement.get(),
-            *ENHANCEMENT_DATA.keys(), command=self.on_enhancement_change,
+            frame,
+            self.app.selected_enhancement,
+            self.app.selected_enhancement.get(),
+            *ENHANCEMENT_DATA.keys(),
+            command=self.on_enhancement_change,
         ).pack(fill=tk.X)
         self.enhancement_parameter_frame = ttk.Frame(frame, padding=(0, 10, 0, 0))
         self.enhancement_parameter_frame.pack(fill=tk.X)
@@ -138,8 +141,11 @@ class ControlPanel:
         frame = ttk.LabelFrame(parent, text="3. Frequency Domain Filters", padding="10")
         frame.pack(side=tk.TOP, fill=tk.X, pady=(0, 10))
         ttk.OptionMenu(
-            frame, self.app.selected_frequency_filter, self.app.selected_frequency_filter.get(),
-            *FREQUENCY_DATA.keys(), command=self.on_frequency_filter_change,
+            frame,
+            self.app.selected_frequency_filter,
+            self.app.selected_frequency_filter.get(),
+            *FREQUENCY_DATA.keys(),
+            command=self.on_frequency_filter_change,
         ).pack(fill=tk.X)
         self.frequency_parameter_frame = ttk.Frame(frame, padding=(0, 10, 0, 0))
         self.frequency_parameter_frame.pack(fill=tk.X)
@@ -151,7 +157,9 @@ class ControlPanel:
     def _build_channel_extractor(self, parent: ttk.Frame) -> None:
         frame = ttk.LabelFrame(parent, text="4. Channel Extractor", padding="10")
         frame.pack(side=tk.TOP, fill=tk.X, pady=(0, 10))
-        ttk.Checkbutton(frame, text="Enable", variable=self.app.channel_enabled, command=self.on_channel_viewer_toggle).pack(anchor="w")
+        ttk.Checkbutton(
+            frame, text="Enable", variable=self.app.channel_enabled, command=self.on_channel_viewer_toggle
+        ).pack(anchor="w")
         self.channel_controls_container = ttk.Frame(frame)
         self.channel_controls_container.pack(fill=tk.X, pady=5)
         self._create_channel_controls()
@@ -159,8 +167,11 @@ class ControlPanel:
     def _create_channel_controls(self) -> None:
         frame1 = create_param_row("Color Space", parent=self.channel_controls_container)
         space_menu = ttk.OptionMenu(
-            frame1, self.app.selected_color_space, self.app.selected_color_space.get(),
-            *CHANNEL_DATA.keys(), command=self.on_color_space_change,
+            frame1,
+            self.app.selected_color_space,
+            self.app.selected_color_space.get(),
+            *CHANNEL_DATA.keys(),
+            command=self.on_color_space_change,
         )
         space_menu.grid(row=0, column=1, sticky="ew")
 
@@ -171,7 +182,9 @@ class ControlPanel:
     def _build_mask_generation(self, parent: ttk.Frame) -> None:
         self.filter_frame = ttk.LabelFrame(parent, text="5. Mask Generation", padding="10")
         self.filter_frame.pack(side=tk.TOP, fill=tk.X, pady=(0, 10))
-        self.filter_menubutton = ttk.Menubutton(self.filter_frame, textvariable=self.app.selected_filter, direction="flush")
+        self.filter_menubutton = ttk.Menubutton(
+            self.filter_frame, textvariable=self.app.selected_filter, direction="flush"
+        )
         filter_menu = tk.Menu(self.filter_menubutton, tearoff=False)
         for name in FILTER_DATA.keys():
             filter_menu.add_radiobutton(label=name, variable=self.app.selected_filter)
@@ -187,12 +200,17 @@ class ControlPanel:
         # Edge detection
         edge_frame = ttk.LabelFrame(self.refinement_frame, text="Edge Detection (Overrides Mask Generation)", padding=5)
         edge_frame.pack(fill=tk.X, pady=5)
-        ttk.Checkbutton(edge_frame, text="Enable", variable=self.app.edge_enabled, command=self.on_edge_toggle).pack(anchor="w")
+        ttk.Checkbutton(edge_frame, text="Enable", variable=self.app.edge_enabled, command=self.on_edge_toggle).pack(
+            anchor="w"
+        )
         self.edge_controls_container = ttk.Frame(edge_frame)
         self.edge_controls_container.pack(fill=tk.X)
         ttk.OptionMenu(
-            self.edge_controls_container, self.app.selected_edge_filter, self.app.selected_edge_filter.get(),
-            *EDGE_DETECTION_DATA.keys(), command=self.on_edge_filter_change,
+            self.edge_controls_container,
+            self.app.selected_edge_filter,
+            self.app.selected_edge_filter.get(),
+            *EDGE_DETECTION_DATA.keys(),
+            command=self.on_edge_filter_change,
         ).pack(fill=tk.X, pady=(5, 0))
         self.edge_parameter_frame = ttk.Frame(self.edge_controls_container, padding=(0, 10, 0, 0))
         self.edge_parameter_frame.pack(fill=tk.X)
@@ -200,7 +218,9 @@ class ControlPanel:
         # Morphological operations
         morph_frame = ttk.LabelFrame(self.refinement_frame, text="Morphological Operations", padding=5)
         morph_frame.pack(fill=tk.X, pady=5)
-        ttk.Checkbutton(morph_frame, text="Enable", variable=self.app.morph_enabled, command=self.on_morph_toggle).pack(anchor="w")
+        ttk.Checkbutton(morph_frame, text="Enable", variable=self.app.morph_enabled, command=self.on_morph_toggle).pack(
+            anchor="w"
+        )
         self.morph_controls_container = ttk.Frame(morph_frame)
         self.morph_controls_container.pack(fill=tk.X)
         self._create_morph_controls()
@@ -241,13 +261,17 @@ class ControlPanel:
     def _build_contour_analysis(self, parent: ttk.Frame) -> None:
         frame = ttk.LabelFrame(parent, text="7. Contour Analysis", padding="10")
         frame.pack(side=tk.TOP, fill=tk.X, pady=(0, 10))
-        ttk.Checkbutton(frame, text="Enable", variable=self.app.contours_enabled, command=self.on_contour_toggle).pack(anchor="w")
+        ttk.Checkbutton(frame, text="Enable", variable=self.app.contours_enabled, command=self.on_contour_toggle).pack(
+            anchor="w"
+        )
         self.contour_controls_container = ttk.Frame(frame)
         self.contour_controls_container.pack(fill=tk.X)
 
         ttk.Checkbutton(
-            self.contour_controls_container, text="Draw Contours on Image",
-            variable=self.app.draw_contours, command=self._apply,
+            self.contour_controls_container,
+            text="Draw Contours on Image",
+            variable=self.app.draw_contours,
+            command=self._apply,
         ).pack(anchor="w", pady=(5, 0))
 
         min_frame = create_param_row("Min Area", parent=self.contour_controls_container)
@@ -257,7 +281,8 @@ class ControlPanel:
         create_slider_and_entry(max_frame, self.app.contour_max_area, 0, 1000000, on_change=self._apply)
 
         ttk.Label(
-            self.contour_controls_container, textvariable=self.app.object_count_text,
+            self.contour_controls_container,
+            textvariable=self.app.object_count_text,
             font=("Helvetica", 10, "bold"),
         ).pack(pady=5)
 
@@ -284,25 +309,37 @@ class ControlPanel:
 
     def on_preproc_change(self, _event: Any = None) -> None:
         build_dynamic_panel(
-            PREPROCESSING_DATA, self.app.selected_preproc.get(),
-            self.preproc_parameter_frame, self.preproc_param_widgets,
-            self.app.param_vars, "preproc", on_change=self._apply,
+            PREPROCESSING_DATA,
+            self.app.selected_preproc.get(),
+            self.preproc_parameter_frame,
+            self.preproc_param_widgets,
+            self.app.param_vars,
+            "preproc",
+            on_change=self._apply,
         )
         self._apply()
 
     def on_enhancement_change(self, _event: Any = None) -> None:
         build_dynamic_panel(
-            ENHANCEMENT_DATA, self.app.selected_enhancement.get(),
-            self.enhancement_parameter_frame, self.enhancement_param_widgets,
-            self.app.param_vars, "enhancement", on_change=self._apply,
+            ENHANCEMENT_DATA,
+            self.app.selected_enhancement.get(),
+            self.enhancement_parameter_frame,
+            self.enhancement_param_widgets,
+            self.app.param_vars,
+            "enhancement",
+            on_change=self._apply,
         )
         self._apply()
 
     def on_frequency_filter_change(self, _event: Any = None) -> None:
         build_dynamic_panel(
-            FREQUENCY_DATA, self.app.selected_frequency_filter.get(),
-            self.frequency_parameter_frame, self.frequency_param_widgets,
-            self.app.param_vars, "frequency", on_change=self._apply,
+            FREQUENCY_DATA,
+            self.app.selected_frequency_filter.get(),
+            self.frequency_parameter_frame,
+            self.frequency_param_widgets,
+            self.app.param_vars,
+            "frequency",
+            on_change=self._apply,
         )
         state = "normal" if self.app.selected_frequency_filter.get() != "None" else "disabled"
         self.show_spectrum_button.config(state=state)
@@ -343,9 +380,13 @@ class ControlPanel:
 
     def on_edge_filter_change(self, _event: Any = None) -> None:
         build_dynamic_panel(
-            EDGE_DETECTION_DATA, self.app.selected_edge_filter.get(),
-            self.edge_parameter_frame, self.edge_param_widgets,
-            self.app.param_vars, "edge", on_change=self._apply,
+            EDGE_DETECTION_DATA,
+            self.app.selected_edge_filter.get(),
+            self.edge_parameter_frame,
+            self.edge_param_widgets,
+            self.app.param_vars,
+            "edge",
+            on_change=self._apply,
         )
         self._apply()
 
@@ -430,7 +471,9 @@ class ControlPanel:
                 self.param_widgets.extend([s1, e1])
                 max_var = tk.IntVar(value=max_val)
                 pv[f"color_{channel}_max"] = max_var
-                s2, e2 = create_slider_and_entry(frame, max_var, min_val, max_val, on_change=self._apply, column_offset=3)
+                s2, e2 = create_slider_and_entry(
+                    frame, max_var, min_val, max_val, on_change=self._apply, column_offset=3
+                )
                 self.param_widgets.extend([s2, e2])
 
         elif config.get("type") == "otsu":
@@ -454,9 +497,13 @@ class ControlPanel:
 
         else:
             build_dynamic_panel(
-                FILTER_DATA, self.app.selected_filter.get(),
-                self.parameter_frame, self.param_widgets,
-                pv, "filter", on_change=self._apply,
+                FILTER_DATA,
+                self.app.selected_filter.get(),
+                self.parameter_frame,
+                self.param_widgets,
+                pv,
+                "filter",
+                on_change=self._apply,
             )
 
     def _on_mousewheel(self, event: tk.Event) -> None:

--- a/src/alchemycv/ui/widgets.py
+++ b/src/alchemycv/ui/widgets.py
@@ -38,8 +38,12 @@ def create_slider_and_entry(
             on_change()
 
     slider = ttk.Scale(
-        parent, from_=min_val, to=max_val, orient=tk.HORIZONTAL,
-        variable=variable, command=_on_slider,
+        parent,
+        from_=min_val,
+        to=max_val,
+        orient=tk.HORIZONTAL,
+        variable=variable,
+        command=_on_slider,
     )
     slider.grid(row=0, column=column_offset + 1, sticky="ew", padx=5)
 
@@ -81,7 +85,10 @@ def build_dynamic_panel(
         if "options" in p_data:
             var = tk.StringVar(value=p_data["default"])
             menu = ttk.OptionMenu(
-                frame, var, p_data["default"], *p_data["options"],
+                frame,
+                var,
+                p_data["default"],
+                *p_data["options"],
                 command=lambda _v: on_change() if on_change else None,
             )
             menu.grid(row=0, column=1, sticky="ew")
@@ -89,7 +96,10 @@ def build_dynamic_panel(
         else:
             var = tk.IntVar(value=p_data["default"])
             slider, entry = create_slider_and_entry(
-                frame, var, p_data["range"][0], p_data["range"][1],
+                frame,
+                var,
+                p_data["range"][0],
+                p_data["range"][1],
                 on_change=on_change,
             )
             widget_list.extend([slider, entry])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,43 @@
+"""Shared test fixtures."""
+
+import numpy as np
+import pytest
+
+
+@pytest.fixture
+def bgr_image_100x100():
+    """100x100 BGR uint8 image with varied content."""
+    np.random.seed(42)
+    return np.random.randint(0, 256, (100, 100, 3), dtype=np.uint8)
+
+
+@pytest.fixture
+def gray_image_100x100():
+    """100x100 grayscale uint8 image."""
+    np.random.seed(42)
+    return np.random.randint(0, 256, (100, 100), dtype=np.uint8)
+
+
+@pytest.fixture
+def bgr_image_1x1():
+    """Tiny 1x1 BGR image for edge-case testing."""
+    return np.array([[[128, 64, 32]]], dtype=np.uint8)
+
+
+@pytest.fixture
+def bgr_image_small():
+    """10x10 BGR image for fast tests."""
+    np.random.seed(99)
+    return np.random.randint(0, 256, (10, 10, 3), dtype=np.uint8)
+
+
+@pytest.fixture
+def black_image():
+    """100x100 all-black BGR image."""
+    return np.zeros((100, 100, 3), dtype=np.uint8)
+
+
+@pytest.fixture
+def white_image():
+    """100x100 all-white BGR image."""
+    return np.full((100, 100, 3), 255, dtype=np.uint8)

--- a/tests/test_channels.py
+++ b/tests/test_channels.py
@@ -1,0 +1,47 @@
+"""Unit tests for pipeline.channels."""
+
+import numpy as np
+import pytest
+
+from alchemycv.pipeline import channels
+
+
+class TestChannelExtraction:
+    @pytest.mark.parametrize(
+        "space,channel",
+        [
+            ("Grayscale", "Intensity"),
+            ("RGB/BGR", "B"),
+            ("RGB/BGR", "G"),
+            ("RGB/BGR", "R"),
+            ("HSV", "H"),
+            ("HSV", "S"),
+            ("HSV", "V"),
+            ("HLS", "H"),
+            ("Lab", "L"),
+            ("YCrCb", "Y"),
+        ],
+    )
+    def test_extraction_returns_single_channel(self, bgr_image_100x100, space, channel):
+        result = channels.process(bgr_image_100x100, space, channel)
+        assert result.ndim == 2
+        assert result.shape == (100, 100)
+        assert result.dtype == np.uint8
+
+    def test_empty_channel_name_falls_back_to_gray(self, bgr_image_100x100):
+        result = channels.process(bgr_image_100x100, "RGB/BGR", "")
+        assert result.ndim == 2
+
+    def test_unknown_color_space(self, bgr_image_100x100):
+        result = channels.process(bgr_image_100x100, "FakeSpace", "X")
+        assert result.ndim == 2
+
+    def test_grayscale_input(self, gray_image_100x100):
+        """Grayscale input should be returned as-is for grayscale space."""
+        result = channels.process(gray_image_100x100, "Grayscale", "Intensity")
+        assert result.ndim == 2
+
+    def test_invalid_channel_name(self, bgr_image_100x100):
+        """Invalid channel name should fall back to index 0."""
+        result = channels.process(bgr_image_100x100, "RGB/BGR", "NonExistent")
+        assert result.ndim == 2

--- a/tests/test_contours.py
+++ b/tests/test_contours.py
@@ -1,0 +1,56 @@
+"""Unit tests for pipeline.contours."""
+
+import numpy as np
+import pytest
+
+from alchemycv.pipeline import contours
+
+
+@pytest.fixture
+def mask_with_objects():
+    """Binary mask with 3 distinct white rectangles."""
+    mask = np.zeros((200, 200), dtype=np.uint8)
+    mask[10:40, 10:40] = 255  # ~900 px area
+    mask[60:90, 60:90] = 255  # ~900 px area
+    mask[120:190, 120:190] = 255  # ~4900 px area
+    return mask
+
+
+class TestContours:
+    def test_finds_objects(self, mask_with_objects):
+        draw_img = np.zeros((200, 200, 3), dtype=np.uint8)
+        result, count = contours.process(mask_with_objects, draw_img, min_area=0, max_area=1_000_000)
+        assert count == 3
+
+    def test_area_filtering_min(self, mask_with_objects):
+        draw_img = np.zeros((200, 200, 3), dtype=np.uint8)
+        result, count = contours.process(mask_with_objects, draw_img, min_area=1000, max_area=1_000_000)
+        assert count == 1  # Only the large rectangle
+
+    def test_area_filtering_max(self, mask_with_objects):
+        draw_img = np.zeros((200, 200, 3), dtype=np.uint8)
+        result, count = contours.process(mask_with_objects, draw_img, min_area=0, max_area=1000)
+        assert count == 2  # Only the two small rectangles
+
+    def test_no_draw(self, mask_with_objects):
+        draw_img = np.zeros((200, 200, 3), dtype=np.uint8)
+        original = draw_img.copy()
+        result, count = contours.process(mask_with_objects, draw_img, draw=False)
+        np.testing.assert_array_equal(result, original)
+
+    def test_draw_on_grayscale(self, mask_with_objects):
+        """Drawing on grayscale should auto-convert to BGR."""
+        gray_img = np.zeros((200, 200), dtype=np.uint8)
+        result, count = contours.process(mask_with_objects, gray_img, draw=True)
+        assert result.ndim == 3  # Should be converted to BGR
+
+    def test_empty_mask(self):
+        mask = np.zeros((50, 50), dtype=np.uint8)
+        draw_img = np.zeros((50, 50, 3), dtype=np.uint8)
+        result, count = contours.process(mask, draw_img)
+        assert count == 0
+
+    def test_draw_changes_image(self, mask_with_objects):
+        draw_img = np.zeros((200, 200, 3), dtype=np.uint8)
+        result, _ = contours.process(mask_with_objects, draw_img, draw=True)
+        assert np.any(result != 0)

--- a/tests/test_edges.py
+++ b/tests/test_edges.py
@@ -1,0 +1,49 @@
+"""Unit tests for pipeline.edges."""
+
+import numpy as np
+import pytest
+
+from alchemycv.pipeline import edges
+
+
+class TestEdgeDetection:
+    def test_canny(self, gray_image_100x100):
+        params = {"edge_Threshold_1": 50, "edge_Threshold_2": 150}
+        result = edges.process(gray_image_100x100, "Canny", params)
+        assert result.shape == (100, 100)
+        assert result.dtype == np.uint8
+
+    @pytest.mark.parametrize("direction", ["X", "Y", "Magnitude"])
+    def test_sobel_directions(self, gray_image_100x100, direction):
+        params = {"edge_Kernel_Size": 3, "edge_Direction": direction}
+        result = edges.process(gray_image_100x100, "Sobel", params)
+        assert result.shape == (100, 100)
+
+    def test_sobel_even_kernel(self, gray_image_100x100):
+        """Even kernel size should be auto-corrected."""
+        params = {"edge_Kernel_Size": 4, "edge_Direction": "Magnitude"}
+        result = edges.process(gray_image_100x100, "Sobel", params)
+        assert result.shape == (100, 100)
+
+    @pytest.mark.parametrize("direction", ["X", "Y", "Magnitude"])
+    def test_prewitt_directions(self, gray_image_100x100, direction):
+        params = {"edge_Direction": direction}
+        result = edges.process(gray_image_100x100, "Prewitt", params)
+        assert result.shape == (100, 100)
+
+    @pytest.mark.parametrize("direction", ["X", "Y", "Magnitude"])
+    def test_roberts_directions(self, gray_image_100x100, direction):
+        params = {"edge_Direction": direction}
+        result = edges.process(gray_image_100x100, "Roberts", params)
+        assert result.shape == (100, 100)
+
+    def test_unknown_detector(self, gray_image_100x100):
+        result = edges.process(gray_image_100x100, "FakeEdge", {})
+        assert result is gray_image_100x100
+
+    def test_canny_on_uniform_image(self):
+        """Uniform image should produce no edges."""
+        uniform = np.full((50, 50), 128, dtype=np.uint8)
+        params = {"edge_Threshold_1": 50, "edge_Threshold_2": 150}
+        result = edges.process(uniform, "Canny", params)
+        assert np.all(result == 0)

--- a/tests/test_enhancement.py
+++ b/tests/test_enhancement.py
@@ -1,0 +1,75 @@
+"""Unit tests for pipeline.enhancement."""
+
+import numpy as np
+
+from alchemycv.pipeline import enhancement
+
+
+class TestEnhancement:
+    def test_none_returns_same(self, bgr_image_100x100):
+        result = enhancement.process(bgr_image_100x100, "None", {})
+        assert result is bgr_image_100x100
+
+    def test_histogram_equalization_bgr(self, bgr_image_100x100):
+        result = enhancement.process(bgr_image_100x100, "Histogram Equalization", {})
+        assert result.shape == bgr_image_100x100.shape
+        assert result.dtype == np.uint8
+
+    def test_histogram_equalization_gray(self, gray_image_100x100):
+        result = enhancement.process(gray_image_100x100, "Histogram Equalization", {})
+        assert result.shape == gray_image_100x100.shape
+
+    def test_clahe(self, bgr_image_100x100):
+        params = {"enhancement_Clip_Limit": 2, "enhancement_Tile_Grid_Size": 8}
+        result = enhancement.process(bgr_image_100x100, "CLAHE", params)
+        assert result.shape == bgr_image_100x100.shape
+
+    def test_clahe_grayscale(self, gray_image_100x100):
+        params = {"enhancement_Clip_Limit": 2, "enhancement_Tile_Grid_Size": 8}
+        result = enhancement.process(gray_image_100x100, "CLAHE", params)
+        assert result.shape == gray_image_100x100.shape
+
+    def test_contrast_stretching(self, bgr_image_100x100):
+        result = enhancement.process(bgr_image_100x100, "Contrast Stretching", {})
+        assert result.shape == bgr_image_100x100.shape
+
+    def test_gamma_correction(self, bgr_image_100x100):
+        params = {"enhancement_Gamma_x100": 150}
+        result = enhancement.process(bgr_image_100x100, "Gamma Correction", params)
+        assert result.shape == bgr_image_100x100.shape
+
+    def test_gamma_identity(self, bgr_image_100x100):
+        """Gamma=1.0 (100) should return nearly identical image."""
+        params = {"enhancement_Gamma_x100": 100}
+        result = enhancement.process(bgr_image_100x100, "Gamma Correction", params)
+        np.testing.assert_array_equal(result, bgr_image_100x100)
+
+    def test_log_transform(self, bgr_image_100x100):
+        result = enhancement.process(bgr_image_100x100, "Log Transform", {})
+        assert result.shape == bgr_image_100x100.shape
+        assert result.dtype == np.uint8
+
+    def test_log_transform_black_image(self, black_image):
+        """Log transform on all-zero image should not crash."""
+        result = enhancement.process(black_image, "Log Transform", {})
+        assert result is black_image
+
+    def test_retinex(self, bgr_image_100x100):
+        params = {"enhancement_Sigma": 30}
+        result = enhancement.process(bgr_image_100x100, "Single-Scale Retinex", params)
+        assert result.shape == bgr_image_100x100.shape
+
+    def test_unsharp_masking(self, bgr_image_100x100):
+        params = {"enhancement_Kernel_Size": 5, "enhancement_Alpha_x10": 15}
+        result = enhancement.process(bgr_image_100x100, "Unsharp Masking", params)
+        assert result.shape == bgr_image_100x100.shape
+
+    def test_unsharp_even_kernel(self, bgr_image_100x100):
+        """Even kernel should be auto-corrected."""
+        params = {"enhancement_Kernel_Size": 4, "enhancement_Alpha_x10": 10}
+        result = enhancement.process(bgr_image_100x100, "Unsharp Masking", params)
+        assert result.shape == bgr_image_100x100.shape
+
+    def test_unknown_returns_original(self, bgr_image_100x100):
+        result = enhancement.process(bgr_image_100x100, "FakeFilter", {})
+        assert result is bgr_image_100x100

--- a/tests/test_frequency.py
+++ b/tests/test_frequency.py
@@ -1,0 +1,70 @@
+"""Unit tests for pipeline.frequency."""
+
+import numpy as np
+import pytest
+
+from alchemycv.pipeline import frequency
+
+
+class TestFrequencyFilter:
+    def test_none_returns_same(self, bgr_image_100x100):
+        result = frequency.process(bgr_image_100x100, "None", {})
+        assert result is bgr_image_100x100
+
+    @pytest.mark.parametrize(
+        "filter_name",
+        [
+            "Ideal Low-Pass",
+            "Gaussian Low-Pass",
+            "Butterworth Low-Pass",
+            "Ideal High-Pass",
+            "Gaussian High-Pass",
+            "Butterworth High-Pass",
+        ],
+    )
+    def test_all_filter_types(self, bgr_image_100x100, filter_name):
+        params = {"frequency_Cutoff_Freq_(D0)": 30, "frequency_Order_(n)": 2}
+        result = frequency.process(bgr_image_100x100, filter_name, params)
+        assert result.shape == bgr_image_100x100.shape
+        assert result.dtype == np.uint8
+
+    def test_grayscale_input(self, gray_image_100x100):
+        params = {"frequency_Cutoff_Freq_(D0)": 30}
+        result = frequency.process(gray_image_100x100, "Ideal Low-Pass", params)
+        assert result.ndim == 2
+
+    def test_d0_zero_lowpass(self, bgr_image_100x100):
+        """D0=0 for low-pass should return an image (all-pass)."""
+        params = {"frequency_Cutoff_Freq_(D0)": 0}
+        result = frequency.process(bgr_image_100x100, "Ideal Low-Pass", params)
+        assert result.shape == bgr_image_100x100.shape
+
+    def test_d0_zero_highpass(self, bgr_image_100x100):
+        """D0=0 for high-pass should return all-zero mask."""
+        params = {"frequency_Cutoff_Freq_(D0)": 0}
+        result = frequency.process(bgr_image_100x100, "Ideal High-Pass", params)
+        assert result.shape == bgr_image_100x100.shape
+
+
+class TestFilterMask:
+    def test_ideal_lowpass_mask_shape(self):
+        mask = frequency.create_filter_mask((64, 64), "Ideal Low-Pass", 20)
+        assert mask.shape == (64, 64)
+        assert mask.dtype == np.float32
+
+    def test_ideal_lowpass_center_is_one(self):
+        mask = frequency.create_filter_mask((64, 64), "Ideal Low-Pass", 20)
+        assert mask[32, 32] == 1.0
+
+    def test_ideal_highpass_center_is_zero(self):
+        mask = frequency.create_filter_mask((64, 64), "Ideal High-Pass", 20)
+        assert mask[32, 32] == 0.0
+
+    def test_butterworth_highpass_no_nan(self):
+        """Butterworth HP at D=0 should not produce NaN."""
+        mask = frequency.create_filter_mask((64, 64), "Butterworth High-Pass", 20, n=2)
+        assert not np.any(np.isnan(mask))
+
+    def test_unknown_filter_returns_ones(self):
+        mask = frequency.create_filter_mask((32, 32), "Unknown", 10)
+        np.testing.assert_array_equal(mask, np.ones((32, 32), np.float32))

--- a/tests/test_masking.py
+++ b/tests/test_masking.py
@@ -1,0 +1,99 @@
+"""Unit tests for pipeline.masking."""
+
+import numpy as np
+
+from alchemycv.pipeline import masking
+
+
+class TestMaskGeneration:
+    def test_grayscale_range(self, bgr_image_100x100):
+        params = {"filter_Min_Value": 50, "filter_Max_Value": 200}
+        mask, otsu = masking.process(bgr_image_100x100, "Grayscale Range", params)
+        assert mask.shape == (100, 100)
+        assert mask.dtype == np.uint8
+        assert otsu is None
+        assert set(np.unique(mask)).issubset({0, 255})
+
+    def test_grayscale_range_min_gt_max(self, bgr_image_100x100):
+        """When min > max, min should be clamped to max."""
+        params = {"filter_Min_Value": 200, "filter_Max_Value": 50}
+        mask, _ = masking.process(bgr_image_100x100, "Grayscale Range", params)
+        assert mask.shape == (100, 100)
+
+    def test_adaptive_threshold(self, bgr_image_100x100):
+        params = {
+            "filter_Adaptive_Method": "Gaussian C",
+            "filter_Threshold_Type": "Binary",
+            "filter_Block_Size": 11,
+            "filter_C_(Constant)": 2,
+        }
+        mask, otsu = masking.process(bgr_image_100x100, "Adaptive Threshold", params)
+        assert mask.shape == (100, 100)
+        assert otsu is None
+
+    def test_adaptive_threshold_even_block(self, bgr_image_100x100):
+        """Even block size should be auto-corrected to odd."""
+        params = {
+            "filter_Adaptive_Method": "Mean C",
+            "filter_Threshold_Type": "Binary Inverted",
+            "filter_Block_Size": 10,
+            "filter_C_(Constant)": 0,
+        }
+        mask, _ = masking.process(bgr_image_100x100, "Adaptive Threshold", params)
+        assert mask.shape == (100, 100)
+
+    def test_otsu(self, bgr_image_100x100):
+        params = {"otsu_Threshold_Type": "Binary"}
+        mask, threshold = masking.process(bgr_image_100x100, "Otsu's Binarization", params)
+        assert mask.shape == (100, 100)
+        assert threshold is not None
+        assert 0 <= threshold <= 255
+
+    def test_otsu_inverted(self, bgr_image_100x100):
+        params = {"otsu_Threshold_Type": "Binary Inverted"}
+        mask, _ = masking.process(bgr_image_100x100, "Otsu's Binarization", params)
+        assert mask.shape == (100, 100)
+
+    def test_color_filter_hsv(self, bgr_image_100x100):
+        params = {
+            "color_H_min": 0,
+            "color_H_max": 179,
+            "color_S_min": 0,
+            "color_S_max": 255,
+            "color_V_min": 0,
+            "color_V_max": 255,
+        }
+        mask, _ = masking.process(bgr_image_100x100, "HSV", params)
+        assert mask.shape == (100, 100)
+        # Full range should select everything
+        assert np.all(mask == 255)
+
+    def test_color_filter_bgr(self, bgr_image_100x100):
+        params = {
+            "color_B_min": 0,
+            "color_B_max": 50,
+            "color_G_min": 0,
+            "color_G_max": 50,
+            "color_R_min": 0,
+            "color_R_max": 50,
+        }
+        mask, _ = masking.process(bgr_image_100x100, "RGB/BGR (Color Filter)", params)
+        assert mask.shape == (100, 100)
+
+    def test_color_filter_on_grayscale(self, gray_image_100x100):
+        """Color filter on grayscale input should return zeros."""
+        params = {
+            "color_B_min": 0,
+            "color_B_max": 255,
+            "color_G_min": 0,
+            "color_G_max": 255,
+            "color_R_min": 0,
+            "color_R_max": 255,
+        }
+        mask, _ = masking.process(gray_image_100x100, "RGB/BGR (Color Filter)", params)
+        assert np.all(mask == 0)
+
+    def test_unknown_filter(self, bgr_image_100x100):
+        mask, _ = masking.process(bgr_image_100x100, "NonExistent", {})
+        assert mask.shape == (100, 100)
+        assert np.all(mask == 0)

--- a/tests/test_morphology.py
+++ b/tests/test_morphology.py
@@ -1,0 +1,92 @@
+"""Unit tests for pipeline.morphology."""
+
+import numpy as np
+import pytest
+
+from alchemycv.pipeline import morphology
+
+
+@pytest.fixture
+def binary_mask():
+    """Binary mask with a white square in the center."""
+    mask = np.zeros((100, 100), dtype=np.uint8)
+    mask[30:70, 30:70] = 255
+    return mask
+
+
+class TestMorphology:
+    @pytest.mark.parametrize(
+        "operation",
+        [
+            "Dilate",
+            "Erode",
+            "Open",
+            "Close",
+            "Gradient",
+            "Top Hat",
+            "Black Hat",
+        ],
+    )
+    def test_all_operations(self, binary_mask, operation):
+        params = {
+            "Morph Operation": operation,
+            "Morph Kernel Shape": "Rectangle",
+            "Morph Kernel Size": 5,
+            "Morph Iterations": 1,
+        }
+        result = morphology.process(binary_mask, params)
+        assert result.shape == binary_mask.shape
+        assert result.dtype == np.uint8
+
+    @pytest.mark.parametrize("shape", ["Rectangle", "Ellipse", "Cross"])
+    def test_all_kernel_shapes(self, binary_mask, shape):
+        params = {
+            "Morph Operation": "Dilate",
+            "Morph Kernel Shape": shape,
+            "Morph Kernel Size": 5,
+            "Morph Iterations": 1,
+        }
+        result = morphology.process(binary_mask, params)
+        assert result.shape == binary_mask.shape
+
+    def test_dilate_expands(self, binary_mask):
+        params = {
+            "Morph Operation": "Dilate",
+            "Morph Kernel Shape": "Rectangle",
+            "Morph Kernel Size": 5,
+            "Morph Iterations": 1,
+        }
+        result = morphology.process(binary_mask, params)
+        assert np.sum(result > 0) > np.sum(binary_mask > 0)
+
+    def test_erode_shrinks(self, binary_mask):
+        params = {
+            "Morph Operation": "Erode",
+            "Morph Kernel Shape": "Rectangle",
+            "Morph Kernel Size": 5,
+            "Morph Iterations": 1,
+        }
+        result = morphology.process(binary_mask, params)
+        assert np.sum(result > 0) < np.sum(binary_mask > 0)
+
+    def test_even_kernel_corrected(self, binary_mask):
+        params = {
+            "Morph Operation": "Dilate",
+            "Morph Kernel Shape": "Rectangle",
+            "Morph Kernel Size": 4,
+            "Morph Iterations": 1,
+        }
+        result = morphology.process(binary_mask, params)
+        assert result.shape == binary_mask.shape
+
+    def test_multiple_iterations(self, binary_mask):
+        params1 = {
+            "Morph Operation": "Erode",
+            "Morph Kernel Shape": "Rectangle",
+            "Morph Kernel Size": 3,
+            "Morph Iterations": 1,
+        }
+        params3 = {**params1, "Morph Iterations": 3}
+        r1 = morphology.process(binary_mask, params1)
+        r3 = morphology.process(binary_mask, params3)
+        assert np.sum(r3 > 0) < np.sum(r1 > 0)

--- a/tests/test_pipeline_integration.py
+++ b/tests/test_pipeline_integration.py
@@ -1,0 +1,241 @@
+"""Integration tests for the full processing pipeline."""
+
+import numpy as np
+import pytest
+
+from alchemycv.pipeline import engine
+
+
+def _base_sel(**overrides):
+    """Return a default selector dict with optional overrides."""
+    defaults = {
+        "preproc": "None",
+        "enhancement": "None",
+        "frequency": "None",
+        "channel_enabled": False,
+        "color_space": "Grayscale",
+        "channel": "Intensity",
+        "filter": "Grayscale Range",
+        "edge_enabled": False,
+        "edge_filter": "Canny",
+        "morph_enabled": False,
+        "contours_enabled": False,
+        "draw_contours": True,
+        "min_area": 50,
+        "max_area": 1_000_000,
+        "display_mode": "Final Result",
+    }
+    defaults.update(overrides)
+    return defaults
+
+
+class TestFullPipeline:
+    def test_basic_run(self, bgr_image_100x100):
+        sel = _base_sel()
+        params = {"filter_Min_Value": 0, "filter_Max_Value": 127}
+        result = engine.run(bgr_image_100x100, sel, params)
+        assert result is not None
+        assert "final" in result
+        assert "mask" in result
+        assert result["final"].shape == bgr_image_100x100.shape
+
+    def test_all_stages_enabled(self, bgr_image_100x100):
+        sel = _base_sel(
+            preproc="Gaussian Blur",
+            enhancement="CLAHE",
+            frequency="Gaussian Low-Pass",
+            edge_enabled=True,
+            edge_filter="Sobel",
+            morph_enabled=True,
+            contours_enabled=True,
+        )
+        params = {
+            "preproc_Kernel_Size": 5,
+            "enhancement_Clip_Limit": 2,
+            "enhancement_Tile_Grid_Size": 8,
+            "frequency_Cutoff_Freq_(D0)": 30,
+            "edge_Kernel_Size": 3,
+            "edge_Direction": "Magnitude",
+            "Morph Operation": "Close",
+            "Morph Kernel Shape": "Ellipse",
+            "Morph Kernel Size": 5,
+            "Morph Iterations": 2,
+        }
+        result = engine.run(bgr_image_100x100, sel, params)
+        assert result is not None
+        assert result["object_count"] is not None
+
+    def test_channel_extraction_with_masking(self, bgr_image_100x100):
+        sel = _base_sel(
+            channel_enabled=True,
+            color_space="HSV",
+            channel="S",
+            filter="Grayscale Range",
+        )
+        params = {"filter_Min_Value": 50, "filter_Max_Value": 200}
+        result = engine.run(bgr_image_100x100, sel, params)
+        assert result is not None
+        assert result["extracted_channel"] is not None
+        assert result["extracted_channel"].ndim == 2
+
+    def test_color_filter_mask(self, bgr_image_100x100):
+        sel = _base_sel(filter="HSV")
+        params = {
+            "color_H_min": 0,
+            "color_H_max": 179,
+            "color_S_min": 0,
+            "color_S_max": 255,
+            "color_V_min": 100,
+            "color_V_max": 255,
+        }
+        result = engine.run(bgr_image_100x100, sel, params)
+        assert result is not None
+
+    def test_otsu_returns_threshold(self, bgr_image_100x100):
+        sel = _base_sel(filter="Otsu's Binarization")
+        params = {"otsu_Threshold_Type": "Binary"}
+        result = engine.run(bgr_image_100x100, sel, params)
+        assert result is not None
+        assert result["otsu_threshold"] is not None
+
+    def test_adaptive_threshold(self, bgr_image_100x100):
+        sel = _base_sel(filter="Adaptive Threshold")
+        params = {
+            "filter_Adaptive_Method": "Gaussian C",
+            "filter_Threshold_Type": "Binary",
+            "filter_Block_Size": 11,
+            "filter_C_(Constant)": 2,
+        }
+        result = engine.run(bgr_image_100x100, sel, params)
+        assert result is not None
+
+    @pytest.mark.parametrize("edge_filter", ["Canny", "Sobel", "Prewitt", "Roberts"])
+    def test_all_edge_detectors_in_pipeline(self, bgr_image_100x100, edge_filter):
+        sel = _base_sel(edge_enabled=True, edge_filter=edge_filter)
+        params = {
+            "edge_Threshold_1": 50,
+            "edge_Threshold_2": 150,
+            "edge_Kernel_Size": 3,
+            "edge_Direction": "Magnitude",
+        }
+        result = engine.run(bgr_image_100x100, sel, params)
+        assert result is not None
+
+    @pytest.mark.parametrize(
+        "freq_filter",
+        [
+            "Ideal Low-Pass",
+            "Gaussian Low-Pass",
+            "Butterworth Low-Pass",
+            "Ideal High-Pass",
+            "Gaussian High-Pass",
+            "Butterworth High-Pass",
+        ],
+    )
+    def test_all_frequency_filters_in_pipeline(self, bgr_image_100x100, freq_filter):
+        sel = _base_sel(frequency=freq_filter, filter="Grayscale Range")
+        params = {
+            "frequency_Cutoff_Freq_(D0)": 30,
+            "frequency_Order_(n)": 2,
+            "filter_Min_Value": 0,
+            "filter_Max_Value": 200,
+        }
+        result = engine.run(bgr_image_100x100, sel, params)
+        assert result is not None
+
+
+class TestEdgeCases:
+    def test_single_pixel_image(self):
+        img = np.array([[[128, 64, 32]]], dtype=np.uint8)
+        sel = _base_sel()
+        params = {"filter_Min_Value": 0, "filter_Max_Value": 255}
+        result = engine.run(img, sel, params)
+        assert result is not None
+        assert result["final"].shape[:2] == (1, 1)
+
+    def test_grayscale_input_to_pipeline(self):
+        """Pipeline expects BGR but should handle edge cases gracefully."""
+        gray = np.random.randint(0, 256, (50, 50), dtype=np.uint8)
+        # Convert to 3-channel to match expected input
+        bgr = np.stack([gray, gray, gray], axis=-1)
+        sel = _base_sel()
+        params = {"filter_Min_Value": 0, "filter_Max_Value": 127}
+        result = engine.run(bgr, sel, params)
+        assert result is not None
+
+    def test_large_image(self):
+        """Verify pipeline handles larger images without error."""
+        img = np.random.randint(0, 256, (500, 500, 3), dtype=np.uint8)
+        sel = _base_sel(preproc="Median Blur")
+        params = {"preproc_Kernel_Size": 3, "filter_Min_Value": 0, "filter_Max_Value": 127}
+        result = engine.run(img, sel, params)
+        assert result is not None
+        assert result["final"].shape == (500, 500, 3)
+
+    def test_all_black_image(self, black_image):
+        sel = _base_sel()
+        params = {"filter_Min_Value": 0, "filter_Max_Value": 127}
+        result = engine.run(black_image, sel, params)
+        assert result is not None
+
+    def test_all_white_image(self, white_image):
+        sel = _base_sel()
+        params = {"filter_Min_Value": 0, "filter_Max_Value": 255}
+        result = engine.run(white_image, sel, params)
+        assert result is not None
+
+
+class TestParameterBoundaries:
+    def test_min_kernel_size(self, bgr_image_100x100):
+        sel = _base_sel(preproc="Gaussian Blur")
+        params = {"preproc_Kernel_Size": 1, "filter_Min_Value": 0, "filter_Max_Value": 127}
+        result = engine.run(bgr_image_100x100, sel, params)
+        assert result is not None
+
+    def test_max_kernel_size(self, bgr_image_100x100):
+        sel = _base_sel(preproc="Gaussian Blur")
+        params = {"preproc_Kernel_Size": 51, "filter_Min_Value": 0, "filter_Max_Value": 127}
+        result = engine.run(bgr_image_100x100, sel, params)
+        assert result is not None
+
+    def test_extreme_gamma(self, bgr_image_100x100):
+        sel = _base_sel(enhancement="Gamma Correction")
+        params = {"enhancement_Gamma_x100": 10, "filter_Min_Value": 0, "filter_Max_Value": 127}
+        result = engine.run(bgr_image_100x100, sel, params)
+        assert result is not None
+
+    def test_high_gamma(self, bgr_image_100x100):
+        sel = _base_sel(enhancement="Gamma Correction")
+        params = {"enhancement_Gamma_x100": 300, "filter_Min_Value": 0, "filter_Max_Value": 127}
+        result = engine.run(bgr_image_100x100, sel, params)
+        assert result is not None
+
+    def test_extreme_cutoff_frequency(self, bgr_image_100x100):
+        sel = _base_sel(frequency="Butterworth Low-Pass")
+        params = {
+            "frequency_Cutoff_Freq_(D0)": 250,
+            "frequency_Order_(n)": 10,
+            "filter_Min_Value": 0,
+            "filter_Max_Value": 127,
+        }
+        result = engine.run(bgr_image_100x100, sel, params)
+        assert result is not None
+
+    def test_canny_zero_thresholds(self, bgr_image_100x100):
+        sel = _base_sel(edge_enabled=True, edge_filter="Canny")
+        params = {"edge_Threshold_1": 0, "edge_Threshold_2": 0}
+        result = engine.run(bgr_image_100x100, sel, params)
+        assert result is not None
+
+    def test_max_morph_iterations(self, bgr_image_100x100):
+        sel = _base_sel(edge_enabled=True, edge_filter="Canny", morph_enabled=True)
+        params = {
+            "edge_Threshold_1": 50,
+            "edge_Threshold_2": 150,
+            "Morph Operation": "Dilate",
+            "Morph Kernel Shape": "Rectangle",
+            "Morph Kernel Size": 3,
+            "Morph Iterations": 20,
+        }
+        result = engine.run(bgr_image_100x100, sel, params)
+        assert result is not None

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -1,0 +1,56 @@
+"""Unit tests for pipeline.preprocessing."""
+
+import numpy as np
+
+from alchemycv.pipeline import preprocessing
+
+
+class TestPreprocessing:
+    def test_none_returns_same(self, bgr_image_100x100):
+        result = preprocessing.process(bgr_image_100x100, "None", {})
+        assert result is bgr_image_100x100
+
+    def test_gaussian_blur(self, bgr_image_100x100):
+        params = {"preproc_Kernel_Size": 5}
+        result = preprocessing.process(bgr_image_100x100, "Gaussian Blur", params)
+        assert result.shape == bgr_image_100x100.shape
+        assert result.dtype == np.uint8
+
+    def test_gaussian_blur_even_kernel_corrected(self, bgr_image_100x100):
+        """Even kernel sizes should be auto-corrected to odd."""
+        params = {"preproc_Kernel_Size": 4}
+        result = preprocessing.process(bgr_image_100x100, "Gaussian Blur", params)
+        assert result.shape == bgr_image_100x100.shape
+
+    def test_median_blur(self, bgr_image_100x100):
+        params = {"preproc_Kernel_Size": 3}
+        result = preprocessing.process(bgr_image_100x100, "Median Blur", params)
+        assert result.shape == bgr_image_100x100.shape
+        assert result.dtype == np.uint8
+
+    def test_bilateral_filter(self, bgr_image_100x100):
+        params = {"preproc_Diameter": 5, "preproc_Sigma_Color": 50, "preproc_Sigma_Space": 50}
+        result = preprocessing.process(bgr_image_100x100, "Bilateral Filter", params)
+        assert result.shape == bgr_image_100x100.shape
+
+    def test_unknown_filter_returns_original(self, bgr_image_100x100):
+        result = preprocessing.process(bgr_image_100x100, "NonExistent", {})
+        assert result is bgr_image_100x100
+
+    def test_blur_actually_smooths(self, bgr_image_100x100):
+        """Blurred image should have less variance than original."""
+        params = {"preproc_Kernel_Size": 15}
+        result = preprocessing.process(bgr_image_100x100, "Gaussian Blur", params)
+        assert np.var(result.astype(float)) < np.var(bgr_image_100x100.astype(float))
+
+    def test_grayscale_input(self, gray_image_100x100):
+        """Preprocessing should handle grayscale input without crashing."""
+        params = {"preproc_Kernel_Size": 5}
+        result = preprocessing.process(gray_image_100x100, "Gaussian Blur", params)
+        assert result.shape == gray_image_100x100.shape
+
+    def test_kernel_size_1(self, bgr_image_100x100):
+        """Kernel size 1 should effectively be a no-op."""
+        params = {"preproc_Kernel_Size": 1}
+        result = preprocessing.process(bgr_image_100x100, "Gaussian Blur", params)
+        np.testing.assert_array_equal(result, bgr_image_100x100)

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -1,0 +1,183 @@
+"""Unit tests for state.manager (UndoManager) and state.settings."""
+
+import json
+import tkinter as tk
+
+import pytest
+
+from alchemycv.state import settings as settings_io
+from alchemycv.state.manager import UndoManager
+
+
+@pytest.fixture
+def tk_root():
+    """Create and destroy a tkinter root for variable tests."""
+    root = tk.Tk()
+    root.withdraw()
+    yield root
+    root.destroy()
+
+
+class FakeApp:
+    """Minimal object with tkinter variables for state capture."""
+
+    def __init__(self, root):
+        self.name = tk.StringVar(master=root, value="test")
+        self.count = tk.IntVar(master=root, value=0)
+        self.flag = tk.BooleanVar(master=root, value=False)
+
+
+class TestUndoManager:
+    def test_initial_state(self):
+        mgr = UndoManager()
+        assert not mgr.can_undo
+        assert not mgr.can_redo
+
+    def test_capture_and_restore(self, tk_root):
+        app = FakeApp(tk_root)
+        param_vars = {"slider_a": tk.IntVar(master=tk_root, value=10)}
+
+        snapshot = UndoManager.capture(app, param_vars)
+        assert ("self", "name") in snapshot
+        assert ("self", "count") in snapshot
+        assert ("param", "slider_a") in snapshot
+        assert snapshot[("self", "name")] == "test"
+        assert snapshot[("param", "slider_a")] == 10
+
+        # Modify state
+        app.name.set("changed")
+        param_vars["slider_a"].set(99)
+
+        # Restore
+        UndoManager.restore(snapshot, app, param_vars)
+        assert app.name.get() == "test"
+        assert param_vars["slider_a"].get() == 10
+
+    def test_push_and_undo(self, tk_root):
+        app = FakeApp(tk_root)
+        param_vars = {}
+        mgr = UndoManager(debounce_sec=0)  # No debounce for testing
+
+        # Push initial state
+        mgr.maybe_push(app, param_vars)
+        assert mgr.can_undo
+
+        # Modify and undo
+        app.name.set("modified")
+        mgr.undo(app, param_vars)
+        assert app.name.get() == "test"
+        assert mgr.can_redo
+
+    def test_redo(self, tk_root):
+        app = FakeApp(tk_root)
+        param_vars = {}
+        mgr = UndoManager(debounce_sec=0)
+
+        # Save state with name="test"
+        mgr.maybe_push(app, param_vars)
+
+        # Change to "v2" and save
+        app.name.set("v2")
+        mgr.maybe_push(app, param_vars)
+
+        # Change to "v3" (current unsaved state)
+        app.name.set("v3")
+
+        # Undo: should restore to "v2" snapshot
+        mgr.undo(app, param_vars)
+        assert app.name.get() == "v2"
+
+        # Undo again: should restore to "test" snapshot
+        mgr.undo(app, param_vars)
+        assert app.name.get() == "test"
+
+        # Redo: should go back to "v2"
+        mgr.redo(app, param_vars)
+        assert app.name.get() == "v2"
+
+    def test_max_undo_limit(self, tk_root):
+        app = FakeApp(tk_root)
+        param_vars = {}
+        mgr = UndoManager(max_undo=3, debounce_sec=0)
+
+        for i in range(5):
+            app.count.set(i)
+            mgr.maybe_push(app, param_vars)
+
+        assert len(mgr.undo_stack) <= 3
+
+    def test_push_clears_redo(self, tk_root):
+        app = FakeApp(tk_root)
+        param_vars = {}
+        mgr = UndoManager(debounce_sec=0)
+
+        mgr.maybe_push(app, param_vars)
+        app.count.set(1)
+        mgr.maybe_push(app, param_vars)
+        mgr.undo(app, param_vars)
+        assert mgr.can_redo
+
+        # New push should clear redo
+        app.count.set(99)
+        mgr.maybe_push(app, param_vars)
+        assert not mgr.can_redo
+
+    def test_undo_empty_returns_false(self, tk_root):
+        mgr = UndoManager()
+        app = FakeApp(tk_root)
+        assert mgr.undo(app, {}) is False
+
+    def test_redo_empty_returns_false(self, tk_root):
+        mgr = UndoManager()
+        app = FakeApp(tk_root)
+        assert mgr.redo(app, {}) is False
+
+
+class TestSettings:
+    def test_save_and_load_roundtrip(self, tk_root, tmp_path):
+        app = FakeApp(tk_root)
+        param_vars = {
+            "slider_x": tk.IntVar(master=tk_root, value=42),
+            "mode": tk.StringVar(master=tk_root, value="auto"),
+        }
+
+        filepath = tmp_path / "settings.json"
+        settings_io.save(app, param_vars, filepath)
+
+        # Verify file is valid JSON
+        with open(filepath) as f:
+            data = json.load(f)
+        assert "param_vars" in data
+        assert data["param_vars"]["slider_x"] == 42
+
+        # Modify state, then load
+        app.name.set("changed")
+        param_vars["slider_x"].set(0)
+        param_vars["mode"].set("manual")
+
+        settings_io.load(app, param_vars, filepath)
+        assert app.name.get() == "test"
+        assert param_vars["slider_x"].get() == 42
+        assert param_vars["mode"].get() == "auto"
+
+    def test_load_ignores_unknown_keys(self, tk_root, tmp_path):
+        app = FakeApp(tk_root)
+        param_vars = {}
+
+        filepath = tmp_path / "settings.json"
+        with open(filepath, "w") as f:
+            json.dump({"nonexistent_var": "foo", "name": "loaded"}, f)
+
+        settings_io.load(app, param_vars, filepath)
+        assert app.name.get() == "loaded"
+
+    def test_load_handles_missing_param_vars(self, tk_root, tmp_path):
+        app = FakeApp(tk_root)
+        param_vars = {"existing": tk.IntVar(master=tk_root, value=0)}
+
+        filepath = tmp_path / "settings.json"
+        with open(filepath, "w") as f:
+            json.dump({"param_vars": {"existing": 77, "missing": 99}}, f)
+
+        settings_io.load(app, param_vars, filepath)
+        assert param_vars["existing"].get() == 77

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,41 @@
+"""Unit tests for utils (image I/O)."""
+
+import numpy as np
+import pytest
+
+from alchemycv.utils import load_image, save_image
+
+
+class TestImageIO:
+    def test_save_and_load_png(self, tmp_path, bgr_image_100x100):
+        filepath = str(tmp_path / "test.png")
+        save_image(bgr_image_100x100, filepath)
+        loaded = load_image(filepath)
+        assert loaded is not None
+        assert loaded.shape == bgr_image_100x100.shape
+        np.testing.assert_array_equal(loaded, bgr_image_100x100)
+
+    def test_save_and_load_jpg(self, tmp_path, bgr_image_100x100):
+        filepath = str(tmp_path / "test.jpg")
+        save_image(bgr_image_100x100, filepath)
+        loaded = load_image(filepath)
+        assert loaded is not None
+        assert loaded.shape == bgr_image_100x100.shape
+        # JPG is lossy, so just check shape, not exact pixels
+
+    def test_save_and_load_bmp(self, tmp_path, bgr_image_100x100):
+        filepath = str(tmp_path / "test.bmp")
+        save_image(bgr_image_100x100, filepath)
+        loaded = load_image(filepath)
+        assert loaded is not None
+        np.testing.assert_array_equal(loaded, bgr_image_100x100)
+
+    def test_load_nonexistent_returns_none(self):
+        result = load_image("/nonexistent/path/image.png")
+        assert result is None
+
+    def test_save_invalid_extension(self, tmp_path, bgr_image_100x100):
+        """Unsupported extension should raise an error."""
+        filepath = str(tmp_path / "test.xyz")
+        with pytest.raises(Exception):
+            save_image(bgr_image_100x100, filepath)


### PR DESCRIPTION
## Summary
- 140 pytest tests covering all 8 pipeline modules, state management, settings, image I/O, and full integration scenarios
- GitHub Actions CI: ruff lint/format + pytest across Python 3.9/3.11/3.12 + build verification
- GitHub Actions publish workflow: triggered on `v*.*.*` tags, publishes to PyPI via trusted publishing
- Dev dependencies (pytest, pytest-cov, ruff) added to `pyproject.toml`
- All existing code formatted to pass ruff lint and format checks

## Test coverage
| Module | Coverage |
|--------|----------|
| pipeline/* | 97-100% |
| state/* | 83-89% |
| utils | 91% |
| constants | 100% |

## Test plan
- [x] All 140 tests pass locally
- [x] ruff check + ruff format pass clean
- [x] Edge cases: single-pixel, large, all-black/white images
- [x] Parameter boundaries: min/max kernel sizes, gamma, cutoff freq
- [ ] CI workflow runs on push (will verify after merge)